### PR TITLE
Missing space

### DIFF
--- a/ceph-install.sh
+++ b/ceph-install.sh
@@ -13,7 +13,7 @@ for i in 0 1 2
 do
     [ -d /var/local/osd$i ] && sudo rm -rf /var/local/osd$i
 done
-[ -f /etc/ceph/ceph.conf] && sudo rm -rf /etc/ceph/ceph.conf
+[ -f /etc/ceph/ceph.conf ] && sudo rm -rf /etc/ceph/ceph.conf
 }
 
 HOST=$(hostname -s)


### PR DESCRIPTION
A missed space causes ceph.conf not be deleted even if it exists.
